### PR TITLE
Make listener and connector fully asynchronous.

### DIFF
--- a/ovsdb-client/src/main/java/com/vmware/ovsdb/service/OvsdbActiveConnectionConnector.java
+++ b/ovsdb-client/src/main/java/com/vmware/ovsdb/service/OvsdbActiveConnectionConnector.java
@@ -14,8 +14,9 @@
 
 package com.vmware.ovsdb.service;
 
-import com.vmware.ovsdb.callback.ConnectionCallback;
 import io.netty.handler.ssl.SslContext;
+
+import java.util.concurrent.CompletableFuture;
 
 public interface OvsdbActiveConnectionConnector {
 
@@ -24,9 +25,10 @@ public interface OvsdbActiveConnectionConnector {
    *
    * @param ip the OVSDB server ip
    * @param port port to which the OVSDB is listening
-   * @param connectionCallback called when the connection is established
+   * @return a {@link CompletableFuture} that will complete with an {@link OvsdbClient}
+   *         object when the connection is established
    */
-  void connect(String ip, int port, ConnectionCallback connectionCallback);
+  CompletableFuture<OvsdbClient> connect(String ip, int port);
 
   /**
    * Connect to the OVSDB server on ip:port with SSL enabled.
@@ -34,9 +36,8 @@ public interface OvsdbActiveConnectionConnector {
    * @param ip the OVSDB server ip
    * @param port port to which the OVSDB is listening
    * @param sslContext the SSL context
-   * @param connectionCallback called when the connection is established
+   * @return a {@link CompletableFuture} that will complete with an {@link OvsdbClient}
+   *         object when the connection is established
    */
-  void connectWithSsl(
-      String ip, int port, SslContext sslContext, ConnectionCallback connectionCallback
-  );
+  CompletableFuture<OvsdbClient> connectWithSsl(String ip, int port, SslContext sslContext);
 }

--- a/ovsdb-client/src/main/java/com/vmware/ovsdb/service/OvsdbPassiveConnectionListener.java
+++ b/ovsdb-client/src/main/java/com/vmware/ovsdb/service/OvsdbPassiveConnectionListener.java
@@ -17,6 +17,8 @@ package com.vmware.ovsdb.service;
 import com.vmware.ovsdb.callback.ConnectionCallback;
 import io.netty.handler.ssl.SslContext;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface OvsdbPassiveConnectionListener {
 
   /**
@@ -24,8 +26,10 @@ public interface OvsdbPassiveConnectionListener {
    *
    * @param port port to listen. Usually it is 6640
    * @param connectionCallback called when there is a connection from the OVSDB server
+   * @return a {@link CompletableFuture} that will complete with true if listening starts
+   *         successfully or false otherwise
    */
-  void startListening(int port, ConnectionCallback connectionCallback);
+  CompletableFuture<Boolean> startListening(int port, ConnectionCallback connectionCallback);
 
   /**
    * Start listening on the specified port with SSL enabled.
@@ -33,13 +37,19 @@ public interface OvsdbPassiveConnectionListener {
    * @param port port to listen. Usually it should  be 6640
    * @param sslContext the SSL context used for SSL connection
    * @param connectionCallback called when there is a connection from the OVSDB server
+   * @return a {@link CompletableFuture} that will complete with true if listening starts
+   *         successfully or false otherwise
    */
-  void startListeningWithSsl(
+  CompletableFuture<Boolean> startListeningWithSsl(
       int port, SslContext sslContext, ConnectionCallback connectionCallback
   );
 
   /**
-   * Stop the OVSDB manager.
+   * Stop listening on the given port.
+   *
+   * @param port the port to stop listening
+   * @return a {@link CompletableFuture} that will complete with true if listening stops
+   *         successfully or false otherwise
    */
-  void stopListening(int port);
+  CompletableFuture<Boolean> stopListening(int port);
 }

--- a/ovsdb-client/src/test/java/com/vmware/ovsdb/service/OvsdbClientActiveConnectionTest.java
+++ b/ovsdb-client/src/test/java/com/vmware/ovsdb/service/OvsdbClientActiveConnectionTest.java
@@ -44,13 +44,13 @@ public class OvsdbClientActiveConnectionTest extends OvsdbClientTest {
   void setUp(boolean withSsl) {
     if (!withSsl) {
       passiveOvsdbServer.startListening().join();
-      activeConnector.connect(HOST, PORT, connectionCallback);
+      ovsdbClient = activeConnector.connect(HOST, PORT).join();
     } else {
       // In passive connection test, the controller is the server and the ovsdb-server is the client
       SslContext serverSslCtx = sslContextPair.getServerSslCtx();
       SslContext clientSslCtx = sslContextPair.getClientSslCtx();
-      passiveOvsdbServer.startListeningWithSsl(serverSslCtx);
-      activeConnector.connectWithSsl(HOST, PORT, clientSslCtx, connectionCallback);
+      passiveOvsdbServer.startListeningWithSsl(serverSslCtx).join();
+      ovsdbClient = activeConnector.connectWithSsl(HOST, PORT, clientSslCtx).join();
     }
   }
 

--- a/ovsdb-client/src/test/java/com/vmware/ovsdb/service/OvsdbClientTest.java
+++ b/ovsdb-client/src/test/java/com/vmware/ovsdb/service/OvsdbClientTest.java
@@ -88,32 +88,12 @@ abstract class OvsdbClientTest {
 
   private static final AtomicInteger id = new AtomicInteger(0);
 
-  private final CompletableFuture<OvsdbClient> connectFuture = new CompletableFuture<>();
-
-  private final CompletableFuture<OvsdbClient> disconnectFuture = new CompletableFuture<>();
-
-  final ConnectionCallback connectionCallback = new ConnectionCallback() {
-    @Override
-    public void connected(OvsdbClient ovsdbClient) {
-      connectFuture.complete(ovsdbClient);
-    }
-
-    @Override
-    public void disconnected(OvsdbClient ovsdbClient) {
-      disconnectFuture.complete(ovsdbClient);
-    }
-  };
-
   SelfSignedSslContextPair sslContextPair;
 
-  private OvsdbClient ovsdbClient;
+  OvsdbClient ovsdbClient;
 
   OvsdbClientTest(OvsdbServerEmulator ovsdbServerEmulator) {
     this.ovsdbServerEmulator = ovsdbServerEmulator;
-    disconnectFuture.thenAccept(disconnectClient -> {
-      assertEquals(disconnectClient, ovsdbClient);
-      ovsdbClient = null;
-    });
     try {
       sslContextPair = newSelfSignedSslContextPair();
     } catch (CertificateException | SSLException e) {
@@ -124,7 +104,6 @@ abstract class OvsdbClientTest {
   abstract void setUp(boolean withSsl);
 
   private void testAll() throws IOException, OvsdbClientException {
-    ovsdbClient = connectFuture.join();
     testListDatabases();
     testGetSchema();
     testInsertTransact();

--- a/ovsdb-client/src/test/java/com/vmware/ovsdb/service/OvsdbPassiveConnectionListenerTest.java
+++ b/ovsdb-client/src/test/java/com/vmware/ovsdb/service/OvsdbPassiveConnectionListenerTest.java
@@ -50,17 +50,17 @@ public class OvsdbPassiveConnectionListenerTest {
 
   private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(10);
 
-  private final OvsdbPassiveConnectionListener passiveConnectionListener =
+  private final OvsdbPassiveConnectionListener passiveListener =
       new OvsdbPassiveConnectionListenerImpl(executorService);
 
   @Test(timeout = TEST_TIMEOUT_MILLIS)
   public void testTcpConnection() throws Exception {
-    passiveConnectionListener.startListening(PORT, mockConnectionCallback);
+    passiveListener.startListening(PORT, mockConnectionCallback).join();
     testConnectionBasic(null);
     testConnectThenDisconnect(null);
     testWriteInvalidJson(null);
     testChannelTimeout(null);
-    passiveConnectionListener.stopListening(PORT);
+    passiveListener.stopListening(PORT).join();
   }
 
   @Test(timeout = TEST_TIMEOUT_MILLIS)
@@ -69,12 +69,12 @@ public class OvsdbPassiveConnectionListenerTest {
     // In passive connection test, the controller is the server and the ovsdb-server is the client
     SslContext serverSslCtx = sslContextPair.getServerSslCtx();
     SslContext clientSslCtx = sslContextPair.getClientSslCtx();
-    passiveConnectionListener.startListeningWithSsl(PORT, serverSslCtx, mockConnectionCallback);
+    passiveListener.startListeningWithSsl(PORT, serverSslCtx, mockConnectionCallback).join();
     testConnectionBasic(clientSslCtx);
     testConnectThenDisconnect(clientSslCtx);
     testWriteInvalidJson(clientSslCtx);
     testChannelTimeout(clientSslCtx);
-    passiveConnectionListener.stopListening(PORT);
+    passiveListener.stopListening(PORT).join();
   }
 
   private void testConnectionBasic(SslContext sslCtx) {


### PR DESCRIPTION
1. Return a Completable future instead of sync() on the bind() and connect()
operations.
2. The interface of active connector is also changed. Now it returns a
CompleteableFuture of OvsdbClient object.

Signed-off-by: Hechao Li <hechaol@outlook.com>